### PR TITLE
Update keys for 2017

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,9 @@
     - 94558F59
     - D2C19886
 
+- name: Add Apt Keys (2017-01)
+  apt_key: keyserver=hkp://keyserver.ubuntu.com:80 id=BBEBDCB318AD50EC6865090613B00F1FD2C19886 state=present
+
 - name: Add repository
   apt_repository: repo='deb http://repository.spotify.com stable non-free'
 


### PR DESCRIPTION
I've left in the old keys/server in case they are relevant to older distros/versions.